### PR TITLE
fix: ensure non-* CORS origin header is set if no req headers sent

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,8 @@ const io = socketIO(server, {
   handlePreflightRequest: function (req, res) {
     var headers = {
       "Access-Control-Allow-Headers": "Content-Type, Authorization",
-      "Access-Control-Allow-Origin": (req.header && req.header.origin) || "https://excalidraw.com",
+      "Access-Control-Allow-Origin":
+        (req.header && req.header.origin) || "https://excalidraw.com",
       "Access-Control-Allow-Credentials": true,
     };
     res.writeHead(200, headers);

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ const io = socketIO(server, {
   handlePreflightRequest: function (req, res) {
     var headers = {
       "Access-Control-Allow-Headers": "Content-Type, Authorization",
-      "Access-Control-Allow-Origin": req.header ? req.header.origin : "*",
+      "Access-Control-Allow-Origin": req.header ? req.header.origin : "https://excalidraw.com",
       "Access-Control-Allow-Credentials": true,
     };
     res.writeHead(200, headers);

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ const io = socketIO(server, {
   handlePreflightRequest: function (req, res) {
     var headers = {
       "Access-Control-Allow-Headers": "Content-Type, Authorization",
-      "Access-Control-Allow-Origin": req.header ? req.header.origin : "https://excalidraw.com",
+      "Access-Control-Allow-Origin": (req.header && req.header.origin) || "https://excalidraw.com",
       "Access-Control-Allow-Credentials": true,
     };
     res.writeHead(200, headers);


### PR DESCRIPTION
fix https://github.com/excalidraw/excalidraw/issues/2775

- `*` is not allowed as `Access-Control-Allow-Origin` header when credentials is set. Setting credentials is outside of our control (https://github.com/socketio/socket.io/issues/3381), so we need to fix it here.