### PR TITLE
Do not broadcast to all rooms on socket disconnect

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -73,11 +73,15 @@ io.on("connection", (socket) => {
   socket.on("disconnecting", () => {
     const rooms = io.sockets.adapter.rooms;
     for (const roomID in socket.rooms) {
-      const clients = Object.keys(rooms[roomID].sockets).filter(
+      const roomSockets = Object.keys(rooms[roomID].sockets);
+      if (!roomSockets.includes(socket.id)) {
+        continue;
+      }
+      const remainingClients = Object.keys(rooms[roomID].sockets).filter(
         (id) => id !== socket.id,
       );
-      if (clients.length > 0) {
-        socket.broadcast.to(roomID).emit("room-user-change", clients);
+      if (remainingClients.length > 0) {
+        socket.broadcast.to(roomID).emit("room-user-change", remainingClients);
       }
     }
   });


### PR DESCRIPTION
## Summary

When a socket disconnects, the server broadcasts to all rooms with at least 1 present collaborator, sending a message that indicates that the collaborators list changed.

That's unnecessary because we only need to notify the room that belongs to the socket that is disconnecting.

This PR addresses this issue.

> Disclaimer: I may not have full context on excalidraw-room and I don't know what was the initial motivation behind broadcasting to all rooms.