### PR TITLE
fix NODE_ENV port priority

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ require("dotenv").config(
 
 const app = express();
 const port =
-  process.env.PORT || process.env.NODE_ENV !== "development" ? 80 : 3002; // default port to listen
+  process.env.PORT || (process.env.NODE_ENV !== "development" ? 80 : 3002); // default port to listen
 
 app.use(express.static("public"));
 


### PR DESCRIPTION
The condition was not prioritizing the `process.env.PORT` value properly. 

If specified, `process.env.PORT` should take precedence over the `NODE_ENV` check. Now, if `process.env.PORT` is defined and truthy, it will be used as the port value. Otherwise, it will fall back to using 80 when the `NODE_ENV` is not "development".