### PR TITLE
fix: for..of in disconnecting event

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -82,9 +82,7 @@ try {
       socketDebug(`${socket.id} has disconnected`);
       for (const roomID of socket.rooms) {
         const otherClients = (await io.in(roomID).fetchSockets()).filter(
-          (_socket) => {
-            return _socket.id !== socket.id;
-          },
+          (_socket) => _socket.id !== socket.id,
         );
 
         if (otherClients.length > 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,9 +80,11 @@ try {
 
     socket.on("disconnecting", async () => {
       socketDebug(`${socket.id} has disconnected`);
-      for (const roomID in socket.rooms) {
+      for (const roomID of socket.rooms) {
         const otherClients = (await io.in(roomID).fetchSockets()).filter(
-          (_socket) => _socket.id !== socket.id,
+          (_socket) => {
+            return _socket.id !== socket.id;
+          },
         );
 
         if (otherClients.length > 0) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2020",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
This small PR fixes the loop in the `disconnecting` handler that caused the proper message wasn't emitted when the client disconnected and increases the transpile target to be able to iterate over `Set` .